### PR TITLE
Feature minimist

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,21 @@
 {
-  "name": "trybe-start",
-  "version": "1.0.2",
+  "name": "trybe-prj",
+  "version": "1.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "trybe-start",
-      "version": "1.0.2",
+      "name": "trybe-prj",
+      "version": "1.2.1",
       "license": "ISC",
       "dependencies": {
         "colors": "^1.4.0",
+        "minimist": "^1.2.6",
         "open": "^8.4.0",
         "readline-sync": "^1.4.10"
       },
       "bin": {
-        "trybe-start": "src/index.js"
+        "trybe-prj": "src/index.js"
       }
     },
     "node_modules/colors": {
@@ -57,6 +58,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "node_modules/open": {
       "version": "8.4.0",
@@ -106,6 +112,11 @@
       "requires": {
         "is-docker": "^2.0.0"
       }
+    },
+    "minimist": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "open": {
       "version": "8.4.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "license": "ISC",
   "dependencies": {
     "colors": "^1.4.0",
+    "minimist": "^1.2.6",
     "open": "^8.4.0",
     "readline-sync": "^1.4.10"
   }

--- a/src/getParams.js
+++ b/src/getParams.js
@@ -1,10 +1,13 @@
+const { _: args, ...options } = require('minimist')(process.argv.slice(2));
+
 const getParams = () => {
-  const params = process.argv.slice(2);
+  const pr = !!options.pr;
+  const code = !!options.code;
 
   const paramsSchema = {
-    pr: params.includes('--pr'),
-    code: params.includes('--code'),
-    clonePath: params.find((param) => param !== '--pr' && param !== '--code'),
+    pr,
+    code,
+    clonePath: args,
   };
 
   return paramsSchema;


### PR DESCRIPTION
A mudança sugerida é para instalar o minimist e fazer uma conversão das opções passadas pela linha de comando (--pr e --code).

Usando o exemplo do README.md, suponhamos que o usuário use o comando:
```{bash}
npx trybe-prj --pr --code talker-manager
```
Com o minimist, podemos passar as opções --pr e --code para um objeto, e os argumentos (talker-manager) para um array de strings. Resultado:
```
args = ['talker-manager']
options = { pr: true, code: true }
```
Dessa forma, fica mais fácil passar novas opções na forma de flags na linha de comando.