### PR TITLE
:bug: fix: Nomes com espaços

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ const getParams = require('./getParams');
 /* Criação e ajuste das variáveis */
 const params = getParams();
 
-const name = readline.question('Digite seu nome e sobrenome:\n-> '.green).trim();
+const name = readline.question('Digite seu nome e sobrenome:\n-> '.green).toLowerCase().trim().replaceAll(' ', '-');
 const repoLink = readline.question('\nQual o link SSH do projeto?\n-> '.green);
 
 const repoUrlPrefix = 'git@github.com:tryber/';
@@ -19,7 +19,7 @@ const repoName = repoLink.replace(repoUrlPrefix, '').replace(repoUrlSufix, '');
 
 const turmaRegex = /(sd-[0-9]{3})(-[a-z]-)/i;
 const projectName = repoName.replace(turmaRegex, '').replace('project-', '');
-let branchName = `${name.toLowerCase().replace(' ', '-')}-${projectName}`;
+let branchName = `${name}-${projectName}`;
 
 const acceptBranchName = readline.keyInYN(
   '\nO nome da branch será: '.green + branchName.green.underline + ', ok?'.green


### PR DESCRIPTION
Este pacote me salvou um bom trabalho qnd ia fazer os projetos da Trybe. Gostei muito de usá-lo. Vi que havia um bug que o nome da minha branch sempre vinha como `jovane-de castro-nome-do-projeto`, então decidi contribuir.
A const `name` já recebe a string tratada com toLowerCase( ), trim( ) e os espaços substituídos por hífens com a função replaceAll( ).